### PR TITLE
New version 0.1.0:

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,4 +1,4 @@
-Copyright (c) 2015 Daniel Loureiro
+Copyright (c) 2020 Daniel Loureiro
 
 MIT License
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ gem 'city-state'
 ## List of states:
 ```ruby
 CS.states(:us)
-# => {:AK=>"Alaska", :AL=>"Alabama", :AR=>"Arkansas", :AZ=>"Arizona", :CA=>"California", :CO=>"Colorado", :CT=>"Connecticut", :DC=>"District of Columbia", :DE=>"Delaware", :FL=>"Florida", :GA=>"Georgia", :HI=>"Hawaii", :IA=>"Iowa", :ID=>"Idaho", :IL=>"Illinois", :IN=>"Indiana", :KS=>"Kansas", :KY=>"Kentucky", :LA=>"Louisiana", :MA=>"Massachusetts", :MD=>"Maryland", :ME=>"Maine", :MI=>"Michigan", :MN=>"Minnesota", :MO=>"Missouri", :MS=>"Mississippi", :MT=>"Montana", :NC=>"North Carolina", :ND=>"North Dakota", :NE=>"Nebraska", :NH=>"New Hampshire", :NJ=>"New Jersey", :NM=>"New Mexico", :NV=>"Nevada", :NY=>"New York", :OH=>"Ohio", :OK=>"Oklahoma", :OR=>"Oregon", :PA=>"Pennsylvania", :RI=>"Rhode Island", :SC=>"South Carolina", :SD=>"South Dakota", :TN=>"Tennessee", :TX=>"Texas", :UT=>"Utah", :VA=>"Virginia", :VT=>"Vermont", :WA=>"Washington", :WI=>"Wisconsin", :WV=>"West Virginia", :WY=>"Wyoming"} 
+# => {:AK=>"Alaska", :AL=>"Alabama", :AR=>"Arkansas", :AZ=>"Arizona", :CA=>"California", :CO=>"Colorado", :CT=>"Connecticut", :DC=>"District of Columbia", :DE=>"Delaware", :FL=>"Florida", :GA=>"Georgia", :HI=>"Hawaii", :IA=>"Iowa", :ID=>"Idaho", :IL=>"Illinois", :IN=>"Indiana", :KS=>"Kansas", :KY=>"Kentucky", :LA=>"Louisiana", :MA=>"Massachusetts", :MD=>"Maryland", :ME=>"Maine", :MI=>"Michigan", :MN=>"Minnesota", :MO=>"Missouri", :MS=>"Mississippi", :MT=>"Montana", :NC=>"North Carolina", :ND=>"North Dakota", :NE=>"Nebraska", :NH=>"New Hampshire", :NJ=>"New Jersey", :NM=>"New Mexico", :NV=>"Nevada", :NY=>"New York", :OH=>"Ohio", :OK=>"Oklahoma", :OR=>"Oregon", :PA=>"Pennsylvania", :RI=>"Rhode Island", :SC=>"South Carolina", :SD=>"South Dakota", :TN=>"Tennessee", :TX=>"Texas", :UT=>"Utah", :VA=>"Virginia", :VT=>"Vermont", :WA=>"Washington", :WI=>"Wisconsin", :WV=>"West Virginia", :WY=>"Wyoming"}
 ```
 **PS:** *city-state is case insensitive. You can use :US, :us, :Us, "us", "US", ...*
 
@@ -38,20 +38,92 @@ CS.get
 ```
 ```ruby
 CS.get :us
-# => {:AK=>"Alaska", :AL=>"Alabama", :AR=>"Arkansas", :AZ=>"Arizona", :CA=>"California", :CO=>"Colorado", :CT=>"Connecticut", :DC=>"District of Columbia", :DE=>"Delaware", :FL=>"Florida", :GA=>"Georgia", :HI=>"Hawaii", :IA=>"Iowa", :ID=>"Idaho", :IL=>"Illinois", :IN=>"Indiana", :KS=>"Kansas", :KY=>"Kentucky", :LA=>"Louisiana", :MA=>"Massachusetts", :MD=>"Maryland", :ME=>"Maine", :MI=>"Michigan", :MN=>"Minnesota", :MO=>"Missouri", :MS=>"Mississippi", :MT=>"Montana", :NC=>"North Carolina", :ND=>"North Dakota", :NE=>"Nebraska", :NH=>"New Hampshire", :NJ=>"New Jersey", :NM=>"New Mexico", :NV=>"Nevada", :NY=>"New York", :OH=>"Ohio", :OK=>"Oklahoma", :OR=>"Oregon", :PA=>"Pennsylvania", :RI=>"Rhode Island", :SC=>"South Carolina", :SD=>"South Dakota", :TN=>"Tennessee", :TX=>"Texas", :UT=>"Utah", :VA=>"Virginia", :VT=>"Vermont", :WA=>"Washington", :WI=>"Wisconsin", :WV=>"West Virginia", :WY=>"Wyoming"} 
+# => {:AK=>"Alaska", :AL=>"Alabama", :AR=>"Arkansas", :AZ=>"Arizona", :CA=>"California", :CO=>"Colorado", :CT=>"Connecticut", :DC=>"District of Columbia", :DE=>"Delaware", :FL=>"Florida", :GA=>"Georgia", :HI=>"Hawaii", :IA=>"Iowa", :ID=>"Idaho", :IL=>"Illinois", :IN=>"Indiana", :KS=>"Kansas", :KY=>"Kentucky", :LA=>"Louisiana", :MA=>"Massachusetts", :MD=>"Maryland", :ME=>"Maine", :MI=>"Michigan", :MN=>"Minnesota", :MO=>"Missouri", :MS=>"Mississippi", :MT=>"Montana", :NC=>"North Carolina", :ND=>"North Dakota", :NE=>"Nebraska", :NH=>"New Hampshire", :NJ=>"New Jersey", :NM=>"New Mexico", :NV=>"Nevada", :NY=>"New York", :OH=>"Ohio", :OK=>"Oklahoma", :OR=>"Oregon", :PA=>"Pennsylvania", :RI=>"Rhode Island", :SC=>"South Carolina", :SD=>"South Dakota", :TN=>"Tennessee", :TX=>"Texas", :UT=>"Utah", :VA=>"Virginia", :VT=>"Vermont", :WA=>"Washington", :WI=>"Wisconsin", :WV=>"West Virginia", :WY=>"Wyoming"}
 ```
 ```ruby
 CS.get :us, :ak
 # => ["Adak", "Akhiok", "Akiachak", "Akiak", "Akutan", "Alakanuk", "Ambler", "Anchor Point", "Anchorage", "Angoon", "Atqasuk", "Barrow", "Bell Island Hot Springs", "Bethel", "Big Lake", "Buckland", "Chefornak", "Chevak", "Chicken", "Chugiak", "Coffman Cove", "Cooper Landing", "Copper Center", "Cordova", "Craig", "Deltana", "Dillingham", "Douglas", "Dutch Harbor", "Eagle River", "Eielson Air Force Base", "Fairbanks", "Fairbanks North Star Borough", "Fort Greely", "Fort Richardson", "Galena", "Girdwood", "Goodnews Bay", "Haines", "Homer", "Hooper Bay", "Juneau", "Kake", "Kaktovik", "Kalskag", "Kenai", "Ketchikan", "Kiana", "King Cove", "King Salmon", "Kipnuk", "Klawock", "Kodiak", "Kongiganak", "Kotlik", "Koyuk", "Kwethluk", "Levelock", "Manokotak", "May Creek", "Mekoryuk", "Metlakatla", "Mountain Village", "Nabesna", "Naknek", "Nazan Village", "Nenana", "New Stuyahok", "Nikiski", "Ninilchik", "Noatak", "Nome", "Nondalton", "Noorvik", "North Pole", "Northway", "Old Kotzebue", "Palmer", "Pedro Bay", "Petersburg", "Pilot Station", "Point Hope", "Point Lay", "Prudhoe Bay", "Russian Mission", "Sand Point", "Scammon Bay", "Selawik", "Seward", "Shungnak", "Sitka", "Skaguay", "Soldotna", "Stebbins", "Sterling", "Sutton", "Talkeetna", "Teller", "Thorne Bay", "Togiak", "Tok", "Toksook Bay", "Tuntutuliak", "Two Rivers", "Unalakleet", "Unalaska", "Valdez", "Wainwright", "Wasilla"]
 ```
 
-## Update the database from MaxMind:
-MaxMind update their databases weekly on tuesdays. To get a new and updated version, you can update with:
+# Missing cities and wrong names
+To add missing cities or to rename wrong ones, create these files in your project folder:
+`db/cities-lookup.yml` and `db/states-lookup.yml` and `db/countries-lookup.yml`:
+
+1) Renaming a country - `US` to `America`:
+```yaml
+# db/countries-lookup.yml
+US: "America"
+```
+
+2) Renaming a state - `California` to `Something Else`:
+```yaml
+# db/states-lookup.yml
+US:
+  CA: Something Else
+```
+
+3) Renaming a city:
+```yaml
+# db/cities-lookup.yml
+US:
+  CA:
+    "Burbank": "Bur Bank"
+```
+
+4) Adding a missing city:
+```yaml
+# db/cities-lookup.yml
+US:
+  CA:
+    "My Town": "My Town"
+```
+
+5) Suppressing a city (set it as a blank line):
+```yaml
+# db/cities-lookup.yml
+US:
+  CA:
+    "Burbank": ""
+```
+
+To use a different file instead of `db\cities-lookup.yml`:
 ```ruby
+CS.set_cities_lookup_file('new-city-names.yml')
+CS.set_states_lookup_file('new-state-names.yml')
+CS.set_countries_lookup_file('new-country-names.yml')
+```
+
+# Update the database from MaxMind
+MaxMind update their databases weekly on Tuesdays.
+
+Since Dec 30, 2019, MaxMind requires a license key (for free) to get download updates.
+
+To get the license key:
+1. Sign up for a MaxMind account: https://www.maxmind.com/en/geolite2/signup
+2. Create a license key: https://www.maxmind.com/en/accounts/current/license-key
+
+To update:
+```ruby
+CS.set_license_key('MY_KEY')
+CS.update
+```
+_*PS:* Replace "_MY_KEY_" with your actual key._
+
+## Manually setting a database file:
+You can use an alternative database file instead of downloading from MaxMind servers:
+```ruby
+CS.set_maxmind_zip_url('/home/daniel/GeoLite2-City-CSV_20200324.zip')
+CS.update
+```
+or
+```ruby
+CS.set_maxmind_zip_url('https://example.com/GeoLite2-City-CSV_20200324.zip')
 CS.update
 ```
 
-## Another countries:
+The file has to be a ZIP file. And it has contains a CVS file named `GeoLite2-City-Locations-en.csv`. This file must be in the MaxMind's GeoLite2 City's format.
+
+# Other countries:
 
 When getting a city list, you can also specifies the country:
 ```ruby
@@ -63,15 +135,25 @@ The country is an optional argument. **city-state** always uses the last country
 CS.states(:br)
 # => {:AC=>"Acre", :AL=>"Alagoas", :AM=>"Amazonas", :AP=>"Amapa", :BA=>"Bahia", :CE=>"Ceara", :DF=>"Federal District", :ES=>"Espirito Santo", :GO=>"Goias", :MA=>"Maranhao", :MG=>"Minas Gerais", :MS=>"Mato Grosso do Sul", :MT=>"Mato Grosso", :PA=>"Para", :PB=>"Paraiba", :PE=>"Pernambuco", :PI=>"Piaui", :PR=>"Parana", :RJ=>"Rio de Janeiro", :RN=>"Rio Grande do Norte", :RO=>"Rondonia", :RR=>"Roraima", :RS=>"Rio Grande do Sul", :SC=>"Santa Catarina", :SE=>"Sergipe", :SP=>"Sao Paulo", :TO=>"Tocantins"}
 CS.cities(:to)
-# => ["Aparecida do Rio Negro", "Araguaína", "Brejinho de Nazare", "Gurupi", "Itaguatins", "Miracema do Tocantins", "Monte Alegre", "Palmas", "Paraiso do Tocantins", "Parana", "Pedro Afonso", "Porto Nacional", "Presidente Kennedy", "Salvador", "Santo Antonio", "Sao Domingos", "Taguatinga", "Tucum"] 
+# => ["Aparecida do Rio Negro", "Araguaína", "Brejinho de Nazare", "Gurupi", "Itaguatins", "Miracema do Tocantins", "Monte Alegre", "Palmas", "Paraiso do Tocantins", "Parana", "Pedro Afonso", "Porto Nacional", "Presidente Kennedy", "Salvador", "Santo Antonio", "Sao Domingos", "Taguatinga", "Tucum"]
 ```
 
+# Changelog
+* 0.1.0:
+  - [Minor] Added `set_license_key(license_key)` and `set_maxmind_zip_url(url)` methods;
+  - [Minor] Removed Rails code, so it can be used on pure Ruby;
+  - [Minor] Allow to rename and to add missing cities;
+  - [Minor] Updated default MaxMind database;
+  - [Fix] Filter duplicated elements (ex. `CS.cities(:ca, :us)` was returning `Burbank` twice);
+  - [Fix] Upgraded dependencies (some had security issues);
+  - [Fix] Calling `CS.cities(nil)` was returning random values;
+
 # More details about this gem
-http://www.learnwithdaniel.com/2015/02/citystate-list-of-cities-and-states-ruby/
+https://learnwithdaniel.com/2015/02/citystate-list-of-countries-cities-and-states-ruby/
 
 # CityState License
 **city-state** is a open source project by Daniel Loureiro with a MIT license. Also, it uses MaxMind open source database.
 
 # MaxMind License
-Database and Contents Copyright (c) 2015 MaxMind, Inc.
+Database and Contents Copyright (c) 2020 MaxMind, Inc.
 This work is licensed under the Creative Commons Attribution 3.0 Unported License. To view a copy of this license, visit http://creativecommons.org/licenses/by/3.0/.

--- a/city-state.gemspec
+++ b/city-state.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.test_files    = spec.files.grep(%r{^(test|spec|features)/})
   spec.require_paths = ["lib"]
 
-  spec.add_development_dependency "bundler", "~> 1.7"
-  spec.add_development_dependency "rake", "~> 10.0"
-  spec.add_runtime_dependency "rubyzip", "~> 1.1"
+  spec.add_development_dependency "bundler", ">= 1.7"
+  spec.add_development_dependency "rake", ">= 10.0"
+  spec.add_runtime_dependency "rubyzip", ">= 1.1"
 end

--- a/lib/city-state.rb
+++ b/lib/city-state.rb
@@ -1,27 +1,51 @@
 require "city-state/version"
+require 'yaml'
 
 module CS
   # CS constants
-  MAXMIND_ZIPPED_URL = "http://geolite.maxmind.com/download/geoip/database/GeoLite2-City-CSV.zip"
   FILES_FOLDER = File.expand_path('../db', __FILE__)
   MAXMIND_DB_FN = File.join(FILES_FOLDER, "GeoLite2-City-Locations-en.csv")
   COUNTRIES_FN = File.join(FILES_FOLDER, "countries.yml")
+  DEFAULT_CITIES_LOOKUP_FN    = 'db/cities-lookup.yml'
+  DEFAULT_STATES_LOOKUP_FN    = 'db/states-lookup.yml'
+  DEFAULT_COUNTRIES_LOOKUP_FN = 'db/countries-lookup.yml'
 
   @countries, @states, @cities = [{}, {}, {}]
   @current_country = nil # :US, :BR, :GB, :JP, ...
+  @maxmind_zip_url = nil
+  @license_key = nil
+
+  # lookup tables for state/cities renaming
+  @cities_lookup_fn = nil
+  @cities_lookup = nil
+  @states_lookup_fn = nil
+  @states_lookup = nil
+  @countries_lookup_fn = nil
+  @countries_lookup = nil
+
+  def self.set_maxmind_zip_url(maxmind_zip_url)
+    @maxmind_zip_url = maxmind_zip_url
+  end
+
+  def self.set_license_key(license_key)
+    url = "https://download.maxmind.com/app/geoip_download?edition_id=GeoLite2-City-CSV&license_key=#{license_key}&suffix=zip"
+    @license_key = license_key
+    self.set_maxmind_zip_url(url)
+  end
 
   def self.update_maxmind
     require "open-uri"
     require "zip"
 
     # get zipped file
-    f_zipped = open(MAXMIND_ZIPPED_URL)
+    return false if !@maxmind_zip_url
+    f_zipped = open(@maxmind_zip_url)
 
     # unzip file:
     # recursively searches for "GeoLite2-City-Locations-en"
     Zip::File.open(f_zipped) do |zip_file|
       zip_file.each do |entry|
-        if entry.name["GeoLite2-City-Locations-en"].present?
+        if self.present?(entry.name["GeoLite2-City-Locations-en"])
           fn = entry.name.split("/").last
           entry.extract(File.join(FILES_FOLDER, fn)) { true } # { true } is to overwrite
           break
@@ -58,7 +82,7 @@ module CS
 
     # some state codes are empty: we'll use "states-replace" in these cases
     states_replace_fn = File.join(FILES_FOLDER, "states-replace.yml")
-    states_replace = YAML::load_file(states_replace_fn).symbolize_keys
+    states_replace = self.symbolize_keys(YAML::load_file(states_replace_fn))
     states_replace = states_replace[country.to_sym] || {} # we need just this country
     states_replace_inv = states_replace.invert # invert key with value, to ease the search
 
@@ -68,14 +92,14 @@ module CS
     File.foreach(MAXMIND_DB_FN) do |line|
       rec = line.split(",")
       next if rec[COUNTRY] != country
-      next if (rec[STATE].blank? && rec[STATE_LONG].blank?) || rec[CITY].blank?
+      next if (self.blank?(rec[STATE]) && self.blank?(rec[STATE_LONG])) || self.blank?(rec[CITY])
 
       # some state codes are empty: we'll use "states-replace" in these cases
-      rec[STATE] = states_replace_inv[rec[STATE_LONG]] if rec[STATE].blank?
-      rec[STATE] = rec[STATE_LONG] if rec[STATE].blank? # there's no correspondent in states-replace: we'll use the long name as code
+      rec[STATE] = states_replace_inv[rec[STATE_LONG]] if self.blank?(rec[STATE])
+      rec[STATE] = rec[STATE_LONG] if self.blank?(rec[STATE]) # there's no correspondent in states-replace: we'll use the long name as code
 
       # some long names are empty: we'll use "states-replace" to get the code
-      rec[STATE_LONG] = states_replace[rec[STATE]] if rec[STATE_LONG].blank?
+      rec[STATE_LONG] = states_replace[rec[STATE]] if self.blank?(rec[STATE_LONG])
 
       # normalize
       rec[STATE] = rec[STATE].to_sym
@@ -108,20 +132,20 @@ module CS
   end
 
   def self.current_country
-    return @current_country if @current_country.present?
+    return @current_country if self.present?(@current_country)
 
     # we don't have used this method yet: discover by the file extension
     fn = Dir[File.join(FILES_FOLDER, "cities.*")].last
-    @current_country = fn.blank? ? nil : fn.split(".").last
-    
+    @current_country = self.blank?(fn) ? nil : fn.split(".").last
+
     # there's no files: we'll install and use :US
-    if @current_country.blank?
+    if self.blank?(@current_country)
       @current_country = :US
       self.install(@current_country)
 
     # we find a file: normalize the extension to something like :US
     else
-      @current_country = @current_country.to_s.upcase.to_sym    
+      @current_country = @current_country.to_s.upcase.to_sym
     end
 
     @current_country
@@ -132,30 +156,128 @@ module CS
   end
 
   def self.cities(state, country = nil)
-    self.current_country = country if country.present? # set as current_country
+    self.current_country = country if self.present?(country) # set as current_country
     country = self.current_country
+    state = state.to_s.upcase.to_sym
 
     # load the country file
-    if @cities[country].blank?
+    if self.blank?(@cities[country])
       cities_fn = File.join(FILES_FOLDER, "cities.#{country.to_s.downcase}")
       self.install(country) if ! File.exists? cities_fn
-      @cities[country] = YAML::load_file(cities_fn).symbolize_keys
+      @cities[country] = self.symbolize_keys(YAML::load_file(cities_fn))
+
+      # Remove duplicated cities
+      @cities[country].each do |key, value|
+        @cities[country][key] = value.uniq || []
+      end
+
+      # Process lookup table
+      lookup = get_cities_lookup(country, state)
+      if ! lookup.nil?
+        lookup.each do |old_value, new_value|
+          if new_value.nil? || self.blank?(new_value)
+            @cities[country][state].delete(old_value)
+          else
+            index = @cities[country][state].index(old_value)
+            if index.nil?
+              @cities[country][state][] = new_value
+            else
+              @cities[country][state][index] = new_value
+            end
+          end
+        end
+        @cities[country][state] = @cities[country][state].sort # sort it alphabetically
+      end
     end
 
-    @cities[country][state.to_s.upcase.to_sym] || []
+    # Return list
+    @cities[country][state]
+  end
+
+  def self.set_cities_lookup_file(filename)
+    @cities_lookup_fn = filename
+    @cities_lookup    = nil
+  end
+
+  def self.set_states_lookup_file(filename)
+    @states_lookup_fn = filename
+    @states_lookup    = nil
+  end
+
+  def self.set_countries_lookup_file(filename)
+    @countries_lookup_fn = filename
+    @countries_lookup    = nil
+  end
+
+  def self.get_cities_lookup(country, state)
+    # lookup file not loaded
+    if @cities_lookup.nil?
+      @cities_lookup_fn  = DEFAULT_CITIES_LOOKUP_FN if @cities_lookup_fn.nil?
+      @cities_lookup_fn  = File.expand_path(@cities_lookup_fn)
+      return nil if ! File.exists?(@cities_lookup_fn)
+      @cities_lookup = self.symbolize_keys(YAML::load_file(@cities_lookup_fn)) # force countries to be symbols
+      @cities_lookup.each { |key, value| @cities_lookup[key] = self.symbolize_keys(value) } # force states to be symbols
+    end
+
+    return nil if ! @cities_lookup.key?(country) || ! @cities_lookup[country].key?(state)
+    @cities_lookup[country][state]
+  end
+
+  def self.get_states_lookup(country)
+    # lookup file not loaded
+    if @states_lookup.nil?
+      @states_lookup_fn  = DEFAULT_STATES_LOOKUP_FN if @states_lookup_fn.nil?
+      @states_lookup_fn  = File.expand_path(@states_lookup_fn)
+      return nil if ! File.exists?(@states_lookup_fn)
+      @states_lookup = self.symbolize_keys(YAML::load_file(@states_lookup_fn)) # force countries to be symbols
+      @states_lookup.each { |key, value| @states_lookup[key] = self.symbolize_keys(value) } # force states to be symbols
+    end
+
+    return nil if ! @states_lookup.key?(country)
+    @states_lookup[country]
+  end
+
+  def self.get_countries_lookup
+    # lookup file not loaded
+    if @countries_lookup.nil?
+      @countries_lookup_fn  = DEFAULT_COUNTRIES_LOOKUP_FN if @countries_lookup_fn.nil?
+      @countries_lookup_fn  = File.expand_path(@countries_lookup_fn)
+      return nil if ! File.exists?(@countries_lookup_fn)
+      @countries_lookup = self.symbolize_keys(YAML::load_file(@countries_lookup_fn)) # force countries to be symbols
+    end
+
+    @countries_lookup
   end
 
   def self.states(country)
+    # Bugfix: https://github.com/loureirorg/city-state/issues/24
+    return {} if country.nil?
+
+    # Set it as current_country
     self.current_country = country # set as current_country
     country = self.current_country # normalized
 
-    # load the country file
-    if @states[country].blank?
+    # Load the country file
+    if self.blank?(@states[country])
       states_fn = File.join(FILES_FOLDER, "states.#{country.to_s.downcase}")
       self.install(country) if ! File.exists? states_fn
-      @states[country] = YAML::load_file(states_fn).symbolize_keys
+      @states[country] = self.symbolize_keys(YAML::load_file(states_fn))
+
+      # Process lookup table
+      lookup = get_states_lookup(country)
+      if ! lookup.nil?
+        lookup.each do |key, value|
+          if value.nil? || self.blank?(value)
+            @states[country].delete(key)
+          else
+            @states[country][key] = value
+          end
+        end
+        @states[country] = @states[country].sort.to_h # sort it alphabetically
+      end
     end
 
+    # Return list
     @states[country] || {}
   end
 
@@ -168,9 +290,9 @@ module CS
       # reads CSV line by line
       File.foreach(MAXMIND_DB_FN) do |line|
         rec = line.split(",")
-        next if rec[COUNTRY].blank? || rec[COUNTRY_LONG].blank? # jump empty records
+        next if self.blank?(rec[COUNTRY]) || self.blank?(rec[COUNTRY_LONG]) # jump empty records
         country = rec[COUNTRY].to_s.upcase.to_sym # normalize to something like :US, :BR
-        if @countries[country].blank?
+        if self.blank?(@countries[country])
           long = rec[COUNTRY_LONG].gsub(/\"/, "") # sometimes names come with a "\" char
           @countries[country] = long
         end
@@ -182,8 +304,23 @@ module CS
       File.chmod(0666, COUNTRIES_FN) # force permissions to rw_rw_rw_ (issue #3)
     else
       # countries.yml exists, just read it
-      @countries = YAML::load_file(COUNTRIES_FN).symbolize_keys
+      @countries = self.symbolize_keys(YAML::load_file(COUNTRIES_FN))
     end
+
+    # Applies `countries-lookup.yml` if exists
+    lookup = self.get_countries_lookup()
+    if ! lookup.nil?
+      lookup.each do |key, value|
+        if value.nil? || self.blank?(value)
+          @countries.delete(key)
+        else
+          @countries[key] = value
+        end
+      end
+      @countries = @countries.sort.to_h # sort it alphabetically
+    end
+
+    # Return countries list
     @countries
   end
 
@@ -193,5 +330,20 @@ module CS
     return self.countries if country.nil?
     return self.states(country) if state.nil?
     return self.cities(state, country)
+  end
+
+  # Emulates Rails' `blank?` method
+  def self.blank?(obj)
+    obj.respond_to?(:empty?) ? !!obj.empty? : !obj
+  end
+
+  # Emulates Rails' `present?` method
+  def self.present?(obj)
+    !self.blank?(obj)
+  end
+
+  # Emulates Rails' `symbolize_keys` method
+  def self.symbolize_keys(obj)
+    obj.transform_keys { |key| key.to_sym rescue key }
   end
 end

--- a/lib/city-state/version.rb
+++ b/lib/city-state/version.rb
@@ -1,3 +1,3 @@
 module CS
-  VERSION = "0.0.13"
+  VERSION = "0.1.0"
 end


### PR DESCRIPTION
  - [Minor] Added `set_license_key(license_key)` and `set_maxmind_zip_url(url)` methods;
  - [Minor] Removed Rails code, so it can be used on pure Ruby;
  - [Minor] Allow to rename and to add missing cities;
  - [Minor] Updated default MaxMind database;
  - [Fix] Filter duplicated elements (ex. `CS.cities(:ca, :us)` was returning `Burbank` twice);
  - [Fix] Upgraded dependencies (some had security issues);
  - [Fix] Calling `CS.cities(nil)` was returning random values;